### PR TITLE
payments: integrar Stripe con checkout, portal, webhook y página de pricing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
 # Para local: stripe listen --forward-to localhost:3000/api/stripe/webhook
 STRIPE_WEBHOOK_SECRET=whsec_...
 
+# Price ID del plan Premium → Stripe Dashboard → Products → copiar price ID
+NEXT_PUBLIC_STRIPE_PRICE_ID=price_...
+
 # ─── Rate limiting (Upstash Redis) ────────────────────────────────────────────
 # https://console.upstash.com → crear database → copiar REST credentials
 UPSTASH_REDIS_REST_URL=https://...upstash.io

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,25 +35,34 @@ App web de interpretación de sueños con IA. Usuarios anónimos pueden interpre
   layout.tsx              # root layout mínimo (pass-through)
   page.tsx                # redirect al locale por defecto
   /[locale]               # routing de i18n (next-intl)
-    layout.tsx            # Server Component — fonts, providers, metadata
+    layout.tsx            # Server Component — fonts, providers, metadata, AuthSessionProvider
     page.tsx              # Server Component — título, ícono, <DreamSection />
+    /sign-in              # página de login
+    /sign-up              # página de registro
     /journal              # diario de sueños (solo premium) — pendiente
-    /sign-in              # pendiente
-    /sign-up              # pendiente
     /profile              # pendiente
     /billing              # pendiente
     /pricing              # pendiente
   /api
     /interpret            # POST — interpretar sueño (con fallback de modelos)
+    /auth
+      /[...nextauth]      # handlers NextAuth v5
+      /register           # POST — registro con email/password
     /journal              # CRUD entradas del diario — pendiente
     /stripe               # pendiente
-    /auth/[...nextauth]   # pendiente
 /components
   dream-section.tsx       # Client island — estado interpretación + TextBox
   text-box.tsx            # Client island — input + llamada a API
+  /auth
+    sign-in-form.tsx      # Client island — formulario login + Google OAuth
+    sign-up-form.tsx      # Client island — formulario registro
+  /providers
+    session-provider.tsx  # Client wrapper de SessionProvider (next-auth/react)
   /ui
-    header.tsx            # Server Component
+    header.tsx            # Server Component (fixed, con UserInfo + AuthButtons)
     footer.tsx            # Server Component
+    auth-buttons.tsx      # Client island — sign-in/sign-up/sign-out
+    user-info.tsx         # Client island — avatar + nombre cuando hay sesión
     locale-switcher.tsx   # Client island — toggle EN/ES con Framer Motion
     animated-heart.tsx    # Client island — corazón palpitante
     # shadcn/ui components...
@@ -65,7 +74,13 @@ App web de interpretación de sueños con IA. Usuarios anónimos pueden interpre
   en.json                 # textos en inglés
   es.json                 # textos en español
 /lib
+  auth.ts                 # NextAuth v5 config — exporta { handlers, signIn, signOut, auth }
+  prisma.ts               # Singleton PrismaClient
   utils.ts                # cn(), etc.
+/prisma
+  schema.prisma           # modelos: User, Account, Session, VerificationToken, DreamEntry
+/types
+  next-auth.d.ts          # extensiones de tipos: session.user.id, session.user.isPremium
 middleware.ts             # next-intl locale routing
 ```
 
@@ -97,20 +112,28 @@ La selección de modelo ocurre en `/api/interpret/route.ts` leyendo `session.use
 ## Variables de entorno
 
 ```env
-# Existentes
+# IA
 OPENROUTER_API_KEY=
 NEXT_PUBLIC_APP_URL=
 
-# Nuevas (MVP)
+# Base de datos
 DATABASE_URL=                    # PostgreSQL (Neon)
-NEXTAUTH_SECRET=
-NEXTAUTH_URL=
+
+# Auth (NextAuth v5 usa AUTH_SECRET, no NEXTAUTH_SECRET)
+AUTH_SECRET=                     # openssl rand -base64 32
+# AUTH_URL solo necesaria fuera de Vercel; en Vercel se auto-detecta
+
+# Google OAuth
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+
+# Stripe
 STRIPE_SECRET_KEY=
 STRIPE_PUBLISHABLE_KEY=
 STRIPE_WEBHOOK_SECRET=
-UPSTASH_REDIS_REST_URL=          # rate limiting
+
+# Rate limiting
+UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 ```
 
@@ -134,7 +157,7 @@ Nunca usar `npm`, `yarn` o `pnpm`.
 
 - **Componentes**: PascalCase, un componente por archivo
 - **API routes**: siempre validar con `zod` antes de procesar
-- **Auth guard**: usar `getServerSession()` en server components / API routes para verificar premium
+- **Auth guard**: usar `auth()` de `@/lib/auth` en Server Components/API routes (NextAuth v5). En Client Components usar `useSession()` de `next-auth/react`
 - **i18n**: nunca hardcodear texto visible al usuario — usar `useTranslations()` o `getTranslations()`
 - **Estilos**: TailwindCSS inline, no CSS modules. Usar `cn()` de `lib/utils.ts` para clases condicionales
 - **Prisma**: importar siempre desde `@/lib/prisma` (singleton), nunca instanciar `new PrismaClient()` directo
@@ -146,7 +169,8 @@ Nunca usar `npm`, `yarn` o `pnpm`.
 
 ### Proteger ruta premium (API)
 ```ts
-const session = await getServerSession(authOptions)
+// NextAuth v5: usar auth() directamente, no getServerSession(authOptions)
+const session = await auth()
 if (!session?.user?.isPremium) {
   return NextResponse.json({ error: 'Premium required' }, { status: 403 })
 }
@@ -172,9 +196,40 @@ const FREE_MODELS = [
 
 ### SSR — Server Components con Client Islands
 Mantener la mayor parte del árbol como Server Components. Solo marcar `"use client"` en el componente más pequeño posible:
-- `header.tsx` → Server Component que importa `<LocaleSwitcher />` (client)
+- `header.tsx` → Server Component que importa `<UserInfo />`, `<AuthButtons />`, `<LocaleSwitcher />` (todos client)
 - `footer.tsx` → Server Component que importa `<AnimatedHeart />` (client)
 - `page.tsx` → Server Component que importa `<DreamSection />` (client)
+
+### Layout body — estructura correcta
+```tsx
+// Usar flex + min-h-screen + pt-12 (NO grid + min-h-dvh que causa layout shift en Chrome)
+<body className="flex flex-col min-h-screen pt-12">
+  <AuthSessionProvider>
+    <NextIntlClientProvider messages={messages}>
+      <Header />  {/* position: fixed, top-0, left-0, right-0, h-12 */}
+      <main className="flex flex-1 flex-col">{children}</main>
+      <Footer />
+    </NextIntlClientProvider>
+  </AuthSessionProvider>
+</body>
+```
+
+### Header fijo — por qué `fixed` y no `sticky`
+`sticky` dentro de un grid con `min-h-dvh` causa layout shift en Chrome al hacer soft navigation (ej. cambio de locale con Framer Motion). Usar `position: fixed` + `pt-12` en body como compensación. `min-h-dvh` cambia dinámicamente en Chrome; usar `min-h-screen` (100vh) es más estable.
+
+### Google OAuth — imágenes de avatar
+Agregar `lh3.googleusercontent.com` a `images.remotePatterns` en `next.config.ts`:
+```ts
+images: {
+  remotePatterns: [{ protocol: "https", hostname: "lh3.googleusercontent.com" }],
+},
+```
+
+### Prisma en Vercel — siempre generar el cliente
+Vercel cachea `node_modules`, por lo que el Prisma Client puede quedar desactualizado. Agregar al build script:
+```json
+"build": "prisma generate && next build"
+```
 
 ### next-intl sin plugin (workaround @swc/core)
 El plugin `createNextIntlPlugin` falla en bun porque el `@swc/core` anidado no tiene binarios nativos. Usar alias manual en `next.config.ts`:
@@ -211,3 +266,7 @@ const event = stripe.webhooks.constructEvent(body, sig, process.env.STRIPE_WEBHO
 - No usar `react-type-animation` — da mala UX para textos largos (carácter por carácter obliga al ojo a seguir el cursor); usar `WordReveal` propio
 - No usar `createNextIntlPlugin` — falla con bun por binarios nativos de `@swc/core`; usar alias manual en `next.config.ts`
 - No asumir que un modelo gratuito de OpenRouter sigue disponible — siempre definir fallbacks
+- No usar `getServerSession(authOptions)` — es la API de NextAuth v4; en v5 usar `auth()` de `@/lib/auth`
+- No usar `NEXTAUTH_SECRET` / `NEXTAUTH_URL` — NextAuth v5 usa `AUTH_SECRET`; `AUTH_URL` solo necesaria fuera de Vercel
+- No usar `grid min-h-dvh` en el body layout — causa layout shift en Chrome al cambiar locale; usar `flex flex-col min-h-screen`
+- No usar `sticky` en el header si el body es grid — usar `fixed` con `pt-12` en body como compensación

--- a/app/[locale]/billing/page.tsx
+++ b/app/[locale]/billing/page.tsx
@@ -1,0 +1,70 @@
+import { getTranslations } from "next-intl/server";
+import { auth } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import { CheckCircle } from "lucide-react";
+import { ManageSubscriptionButton } from "@/components/billing/manage-subscription-button";
+
+export default async function BillingPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<{ success?: string; canceled?: string }>;
+}) {
+  const { locale } = await params;
+  const { success, canceled } = await searchParams;
+  const [t, session] = await Promise.all([getTranslations("Billing"), auth()]);
+
+  if (!session?.user) redirect(`/${locale}/sign-in`);
+
+  return (
+    <div className="flex flex-1 flex-col items-center px-4 py-16">
+      <div className="w-full max-w-md flex flex-col gap-6">
+
+        {success && (
+          <div className="flex items-center gap-3 rounded-xl bg-primary/10 border border-primary/20 px-4 py-3">
+            <CheckCircle className="w-5 h-5 text-primary shrink-0" />
+            <p className="text-sm text-foreground">{t("successMessage")}</p>
+          </div>
+        )}
+
+        {canceled && (
+          <div className="flex items-center gap-3 rounded-xl bg-muted border border-border px-4 py-3">
+            <p className="text-sm text-muted-foreground">{t("canceledMessage")}</p>
+          </div>
+        )}
+
+        <div className="rounded-2xl border border-border bg-background/90 backdrop-blur-md px-8 py-8 flex flex-col gap-6">
+          <div>
+            <h1 className="text-xl font-semibold text-foreground">{t("title")}</h1>
+            <p className="text-sm text-muted-foreground mt-1">{t("subtitle")}</p>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">{t("currentPlan")}</span>
+            <span className={`rounded-full px-3 py-0.5 text-xs font-semibold ${
+              session.user.isPremium
+                ? "bg-gradient-to-r from-primary to-secondary text-primary-foreground"
+                : "bg-muted text-muted-foreground border border-border"
+            }`}>
+              {session.user.isPremium ? "Premium" : t("freePlan")}
+            </span>
+          </div>
+
+          {session.user.isPremium ? (
+            <ManageSubscriptionButton locale={locale} />
+          ) : (
+            <Link
+              href={`/${locale}/pricing`}
+              className="w-full text-center rounded-full bg-gradient-to-r from-primary to-secondary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-md hover:opacity-90 transition-opacity"
+            >
+              {t("upgradeToPremium")}
+            </Link>
+          )}
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/pricing/page.tsx
+++ b/app/[locale]/pricing/page.tsx
@@ -1,0 +1,33 @@
+import { getTranslations } from "next-intl/server";
+import { auth } from "@/lib/auth";
+import { PricingCards } from "@/components/pricing/pricing-cards";
+
+export default async function PricingPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const [t, session] = await Promise.all([
+    getTranslations("Pricing"),
+    auth(),
+  ]);
+
+  return (
+    <div className="flex flex-1 flex-col items-center px-4 py-16">
+      <div
+        className="opacity-0 flex flex-col items-center gap-2 mb-12"
+        style={{ animation: "fade-up 0.6s ease-out 0.1s both" }}
+      >
+        <h1 className="text-4xl md:text-5xl font-bold text-center bg-gradient-to-br from-primary via-primary/80 to-secondary bg-clip-text text-transparent">
+          {t("title")}
+        </h1>
+        <p className="text-muted-foreground text-center max-w-md">
+          {t("subtitle")}
+        </p>
+      </div>
+
+      <PricingCards locale={locale} isPremium={session?.user?.isPremium ?? false} />
+    </div>
+  );
+}

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { stripe } from "@/lib/stripe";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { priceId, locale } = await req.json();
+  if (!priceId) {
+    return NextResponse.json({ error: "Missing priceId" }, { status: 400 });
+  }
+
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const lang = locale ?? "es";
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { email: true, stripeCustomerId: true },
+  });
+
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 });
+  }
+
+  // Reutilizar customer existente o crear uno nuevo
+  let customerId = user.stripeCustomerId ?? undefined;
+  if (!customerId) {
+    const customer = await stripe.customers.create({
+      email: user.email ?? undefined,
+      metadata: { userId: session.user.id },
+    });
+    customerId = customer.id;
+    await prisma.user.update({
+      where: { id: session.user.id },
+      data: { stripeCustomerId: customerId },
+    });
+  }
+
+  const checkoutSession = await stripe.checkout.sessions.create({
+    customer: customerId,
+    mode: "subscription",
+    payment_method_types: ["card"],
+    line_items: [{ price: priceId, quantity: 1 }],
+    success_url: `${baseUrl}/${lang}/billing?success=true`,
+    cancel_url: `${baseUrl}/${lang}/pricing?canceled=true`,
+    metadata: { userId: session.user.id },
+  });
+
+  return NextResponse.json({ url: checkoutSession.url });
+}

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -14,7 +14,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Missing priceId" }, { status: 400 });
   }
 
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const origin = req.headers.get("origin") ?? req.headers.get("referer")?.replace(/\/$/, "");
+  const baseUrl = origin ?? process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
   const lang = locale ?? "es";
 
   const user = await prisma.user.findUnique({
@@ -26,29 +27,35 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
   }
 
-  // Reutilizar customer existente o crear uno nuevo
-  let customerId = user.stripeCustomerId ?? undefined;
-  if (!customerId) {
-    const customer = await stripe.customers.create({
-      email: user.email ?? undefined,
+  try {
+    // Reutilizar customer existente o crear uno nuevo
+    let customerId = user.stripeCustomerId ?? undefined;
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: user.email ?? undefined,
+        metadata: { userId: session.user.id },
+      });
+      customerId = customer.id;
+      await prisma.user.update({
+        where: { id: session.user.id },
+        data: { stripeCustomerId: customerId },
+      });
+    }
+
+    const checkoutSession = await stripe.checkout.sessions.create({
+      customer: customerId,
+      mode: "subscription",
+      payment_method_types: ["card"],
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: `${baseUrl}/${lang}/billing?success=true`,
+      cancel_url: `${baseUrl}/${lang}/pricing?canceled=true`,
       metadata: { userId: session.user.id },
     });
-    customerId = customer.id;
-    await prisma.user.update({
-      where: { id: session.user.id },
-      data: { stripeCustomerId: customerId },
-    });
+
+    return NextResponse.json({ url: checkoutSession.url });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Stripe error";
+    console.error("[checkout]", message);
+    return NextResponse.json({ error: message }, { status: 500 });
   }
-
-  const checkoutSession = await stripe.checkout.sessions.create({
-    customer: customerId,
-    mode: "subscription",
-    payment_method_types: ["card"],
-    line_items: [{ price: priceId, quantity: 1 }],
-    success_url: `${baseUrl}/${lang}/billing?success=true`,
-    cancel_url: `${baseUrl}/${lang}/pricing?canceled=true`,
-    metadata: { userId: session.user.id },
-  });
-
-  return NextResponse.json({ url: checkoutSession.url });
 }

--- a/app/api/stripe/portal/route.ts
+++ b/app/api/stripe/portal/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { stripe } from "@/lib/stripe";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { locale } = await req.json().catch(() => ({}));
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const lang = locale ?? "es";
+
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    select: { stripeCustomerId: true },
+  });
+
+  if (!user?.stripeCustomerId) {
+    return NextResponse.json(
+      { error: "No active subscription" },
+      { status: 400 }
+    );
+  }
+
+  const portalSession = await stripe.billingPortal.sessions.create({
+    customer: user.stripeCustomerId,
+    return_url: `${baseUrl}/${lang}/billing`,
+  });
+
+  return NextResponse.json({ url: portalSession.url });
+}

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -98,12 +98,16 @@ export async function POST(req: Request) {
         const user = await getUserByCustomerId(customerId);
         if (!user) break;
 
+        // En Stripe API v2026 el subscription está en invoice.parent.subscription_details
+        const subDetails = invoice.parent?.subscription_details;
+        const subId = subDetails
+          ? (typeof subDetails.subscription === "string"
+              ? subDetails.subscription
+              : subDetails.subscription?.id)
+          : undefined;
+
         // No revocar acceso de inmediato — Stripe reintentará
         // Solo revocar si la suscripción ya está en estado past_due/unpaid
-        const subId = typeof invoice.subscription === "string"
-          ? invoice.subscription
-          : invoice.subscription?.id;
-
         if (subId) {
           const subscription = await stripe.subscriptions.retrieve(subId);
           if (subscription.status === "past_due" || subscription.status === "unpaid") {

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -3,9 +3,6 @@ import { stripe } from "@/lib/stripe";
 import { prisma } from "@/lib/prisma";
 import Stripe from "stripe";
 
-// Necesario para leer el raw body y verificar la firma de Stripe
-export const config = { api: { bodyParser: false } };
-
 async function getUserByCustomerId(customerId: string) {
   return prisma.user.findFirst({
     where: { stripeCustomerId: customerId },

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,126 @@
+import { NextResponse } from "next/server";
+import { stripe } from "@/lib/stripe";
+import { prisma } from "@/lib/prisma";
+import Stripe from "stripe";
+
+// Necesario para leer el raw body y verificar la firma de Stripe
+export const config = { api: { bodyParser: false } };
+
+async function getUserByCustomerId(customerId: string) {
+  return prisma.user.findFirst({
+    where: { stripeCustomerId: customerId },
+  });
+}
+
+async function setUserPremium(userId: string, isPremium: boolean, subscriptionId?: string | null) {
+  await prisma.user.update({
+    where: { id: userId },
+    data: {
+      isPremium,
+      stripeSubscriptionId: subscriptionId ?? undefined,
+    },
+  });
+}
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  const sig = req.headers.get("stripe-signature");
+
+  if (!sig) {
+    return NextResponse.json({ error: "Missing stripe-signature" }, { status: 400 });
+  }
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET!
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return NextResponse.json({ error: `Webhook error: ${message}` }, { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object as Stripe.Checkout.Session;
+        if (session.mode !== "subscription") break;
+
+        const customerId = session.customer as string;
+        const subscriptionId = session.subscription as string;
+        const userId = session.metadata?.userId;
+
+        // Guardar stripeCustomerId si no está guardado aún (caso edge)
+        if (userId) {
+          await prisma.user.update({
+            where: { id: userId },
+            data: { stripeCustomerId: customerId },
+          });
+        }
+
+        const user = userId
+          ? await prisma.user.findUnique({ where: { id: userId } })
+          : await getUserByCustomerId(customerId);
+
+        if (user) {
+          await setUserPremium(user.id, true, subscriptionId);
+        }
+        break;
+      }
+
+      case "customer.subscription.updated": {
+        const subscription = event.data.object as Stripe.Subscription;
+        const customerId = subscription.customer as string;
+        const user = await getUserByCustomerId(customerId);
+        if (!user) break;
+
+        const isActive =
+          subscription.status === "active" || subscription.status === "trialing";
+        await setUserPremium(user.id, isActive, subscription.id);
+        break;
+      }
+
+      case "customer.subscription.deleted": {
+        const subscription = event.data.object as Stripe.Subscription;
+        const customerId = subscription.customer as string;
+        const user = await getUserByCustomerId(customerId);
+        if (!user) break;
+
+        await setUserPremium(user.id, false, null);
+        break;
+      }
+
+      case "invoice.payment_failed": {
+        const invoice = event.data.object as Stripe.Invoice;
+        const customerId = invoice.customer as string;
+        const user = await getUserByCustomerId(customerId);
+        if (!user) break;
+
+        // No revocar acceso de inmediato — Stripe reintentará
+        // Solo revocar si la suscripción ya está en estado past_due/unpaid
+        const subId = typeof invoice.subscription === "string"
+          ? invoice.subscription
+          : invoice.subscription?.id;
+
+        if (subId) {
+          const subscription = await stripe.subscriptions.retrieve(subId);
+          if (subscription.status === "past_due" || subscription.status === "unpaid") {
+            await setUserPremium(user.id, false, subId);
+          }
+        }
+        break;
+      }
+
+      default:
+        // Ignorar eventos no manejados
+        break;
+    }
+  } catch (err) {
+    console.error(`[webhook] Error handling ${event.type}:`, err);
+    return NextResponse.json({ error: "Handler error" }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@radix-ui/react-slot": "1.2.2",
         "@radix-ui/react-tabs": "1.1.11",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@stripe/stripe-js": "^8.9.0",
         "@vercel/analytics": "^1.5.0",
         "ai": "4.3.16",
         "bcryptjs": "^3.0.3",
@@ -23,6 +24,7 @@
         "prisma": "^5",
         "react": "19.0.0",
         "react-dom": "19.0.0",
+        "stripe": "^20.4.1",
         "tailwind-merge": "3.3.0",
         "vercel": "^50.32.5",
         "zod": "^4.3.6",
@@ -459,6 +461,8 @@
     "@schummar/icu-type-parser": ["@schummar/icu-type-parser@1.21.5", "", {}, "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.25.24", "", {}, "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="],
+
+    "@stripe/stripe-js": ["@stripe/stripe-js@8.9.0", "", {}, "sha512-OJkXvUI5GAc56QdiSRimQDvWYEqn475J+oj8RzRtFTCPtkJNO2TWW619oDY+nn1ExR+2tCVTQuRQBbR4dRugww=="],
 
     "@swc/core": ["@swc/core@1.15.18", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.18", "@swc/core-darwin-x64": "1.15.18", "@swc/core-linux-arm-gnueabihf": "1.15.18", "@swc/core-linux-arm64-gnu": "1.15.18", "@swc/core-linux-arm64-musl": "1.15.18", "@swc/core-linux-x64-gnu": "1.15.18", "@swc/core-linux-x64-musl": "1.15.18", "@swc/core-win32-arm64-msvc": "1.15.18", "@swc/core-win32-ia32-msvc": "1.15.18", "@swc/core-win32-x64-msvc": "1.15.18" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA=="],
 
@@ -1399,6 +1403,8 @@
     "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "stripe": ["stripe@20.4.1", "", { "peerDependencies": { "@types/node": ">=16" }, "optionalPeers": ["@types/node"] }, "sha512-axCguHItc8Sxt0HC6aSkdVRPffjYPV7EQqZRb2GkIa8FzWDycE7nHJM19C6xAIynH1Qp1/BHiopSi96jGBxT0w=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 

--- a/components/billing/manage-subscription-button.tsx
+++ b/components/billing/manage-subscription-button.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+
+export function ManageSubscriptionButton({ locale }: { locale: string }) {
+  const t = useTranslations("Billing");
+  const [loading, setLoading] = useState(false);
+
+  const handlePortal = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/stripe/portal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ locale }),
+      });
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handlePortal}
+      disabled={loading}
+      className="w-full rounded-full border border-primary/60 px-4 py-2 text-sm text-primary hover:bg-primary/10 transition-colors disabled:opacity-60"
+    >
+      {loading ? t("loading") : t("manageSubscription")}
+    </button>
+  );
+}

--- a/components/pricing/pricing-cards.tsx
+++ b/components/pricing/pricing-cards.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Check } from "lucide-react";
+import { useState } from "react";
+export function PricingCards({
+  locale,
+  isPremium,
+}: {
+  locale: string;
+  isPremium: boolean;
+}) {
+  const t = useTranslations("Pricing");
+  const [loading, setLoading] = useState(false);
+
+  const handleUpgrade = async () => {
+    const priceId = process.env.NEXT_PUBLIC_STRIPE_PRICE_ID;
+    if (!priceId) return;
+
+    setLoading(true);
+    try {
+      const res = await fetch("/api/stripe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ priceId, locale }),
+      });
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePortal = async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/stripe/portal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ locale }),
+      });
+      const data = await res.json();
+      if (data.url) window.location.href = data.url;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const freeFeatures = [
+    t("free.feature1"),
+    t("free.feature2"),
+    t("free.feature3"),
+  ];
+
+  const premiumFeatures = [
+    t("premium.feature1"),
+    t("premium.feature2"),
+    t("premium.feature3"),
+    t("premium.feature4"),
+  ];
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full max-w-3xl">
+      {/* Free */}
+      <div
+        className="opacity-0 flex flex-col rounded-2xl border border-border bg-background/90 backdrop-blur-md px-8 py-8 gap-6"
+        style={{ animation: "fade-up 0.6s ease-out 0.2s both" }}
+      >
+        <div>
+          <span className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            {t("free.badge")}
+          </span>
+          <div className="mt-2 flex items-end gap-1">
+            <span className="text-4xl font-bold text-foreground">$0</span>
+            <span className="text-muted-foreground mb-1">{t("perMonth")}</span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">{t("free.description")}</p>
+        </div>
+
+        <ul className="flex flex-col gap-2 flex-1">
+          {freeFeatures.map((f) => (
+            <li key={f} className="flex items-center gap-2 text-sm text-foreground/80">
+              <Check className="w-4 h-4 text-primary shrink-0" />
+              {f}
+            </li>
+          ))}
+        </ul>
+
+        <button
+          disabled
+          className="w-full rounded-full border border-border px-4 py-2 text-sm text-muted-foreground cursor-default"
+        >
+          {t("free.cta")}
+        </button>
+      </div>
+
+      {/* Premium */}
+      <div
+        className="opacity-0 flex flex-col rounded-2xl border border-primary/40 bg-primary/5 backdrop-blur-md px-8 py-8 gap-6 relative overflow-hidden"
+        style={{ animation: "fade-up 0.6s ease-out 0.3s both" }}
+      >
+        <div className="absolute top-4 right-4">
+          <span className="rounded-full bg-gradient-to-r from-primary to-secondary px-3 py-0.5 text-xs font-semibold text-primary-foreground">
+            {t("premium.badge")}
+          </span>
+        </div>
+
+        <div>
+          <span className="text-xs font-semibold uppercase tracking-wider text-primary">
+            Premium
+          </span>
+          <div className="mt-2 flex items-end gap-1">
+            <span className="text-4xl font-bold text-foreground">
+              {t("premium.price")}
+            </span>
+            <span className="text-muted-foreground mb-1">{t("perMonth")}</span>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">{t("premium.description")}</p>
+        </div>
+
+        <ul className="flex flex-col gap-2 flex-1">
+          {premiumFeatures.map((f) => (
+            <li key={f} className="flex items-center gap-2 text-sm text-foreground/80">
+              <Check className="w-4 h-4 text-primary shrink-0" />
+              {f}
+            </li>
+          ))}
+        </ul>
+
+        {isPremium ? (
+          <button
+            onClick={handlePortal}
+            disabled={loading}
+            className="w-full rounded-full border border-primary/60 px-4 py-2 text-sm text-primary hover:bg-primary/10 transition-colors disabled:opacity-60"
+          >
+            {loading ? t("loading") : t("premium.manage")}
+          </button>
+        ) : (
+          <button
+            onClick={handleUpgrade}
+            disabled={loading}
+            className="w-full rounded-full bg-gradient-to-r from-primary to-secondary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-md hover:opacity-90 transition-opacity disabled:opacity-60"
+          >
+            {loading ? t("loading") : t("premium.cta")}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,11 @@
+import Stripe from "stripe";
+
+const globalForStripe = globalThis as unknown as { stripe: Stripe };
+
+export const stripe =
+  globalForStripe.stripe ??
+  new Stripe(process.env.STRIPE_SECRET_KEY!, {
+    apiVersion: "2026-02-25.clover",
+  });
+
+if (process.env.NODE_ENV !== "production") globalForStripe.stripe = stripe;

--- a/messages/en.json
+++ b/messages/en.json
@@ -17,6 +17,17 @@
     "interpreting": "Interpreting...",
     "clearDream": "Clear dream"
   },
+  "Billing": {
+    "title": "Your subscription",
+    "subtitle": "Manage your plan and payment methods",
+    "currentPlan": "Current plan",
+    "freePlan": "Free",
+    "upgradeToPremium": "Upgrade to Premium",
+    "manageSubscription": "Manage subscription",
+    "loading": "Loading...",
+    "successMessage": "Payment successful! You now have access to Premium.",
+    "canceledMessage": "Payment was canceled. You can try again whenever you're ready."
+  },
   "Pricing": {
     "title": "Simple, transparent pricing",
     "subtitle": "Start for free and upgrade whenever you're ready.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -17,6 +17,31 @@
     "interpreting": "Interpreting...",
     "clearDream": "Clear dream"
   },
+  "Pricing": {
+    "title": "Simple, transparent pricing",
+    "subtitle": "Start for free and upgrade whenever you're ready.",
+    "perMonth": "/ month",
+    "loading": "Loading...",
+    "free": {
+      "badge": "Free",
+      "description": "To explore the meaning of your dreams",
+      "feature1": "3 interpretations per day",
+      "feature2": "Basic AI model",
+      "feature3": "No account needed",
+      "cta": "Current plan"
+    },
+    "premium": {
+      "badge": "Popular",
+      "price": "$4.99",
+      "description": "For those who want to dive deeper into their dreams",
+      "feature1": "Unlimited interpretations",
+      "feature2": "Advanced AI model (Claude)",
+      "feature3": "Private dream journal",
+      "feature4": "Full history",
+      "cta": "Get Premium",
+      "manage": "Manage subscription"
+    }
+  },
   "Auth": {
     "signIn": "Sign in",
     "signUp": "Create account",

--- a/messages/es.json
+++ b/messages/es.json
@@ -17,6 +17,31 @@
     "interpreting": "Interpretando...",
     "clearDream": "Borrar sueño"
   },
+  "Pricing": {
+    "title": "Planes simples y transparentes",
+    "subtitle": "Empieza gratis y actualiza cuando quieras acceder a más.",
+    "perMonth": "/ mes",
+    "loading": "Cargando...",
+    "free": {
+      "badge": "Gratis",
+      "description": "Para explorar el significado de tus sueños",
+      "feature1": "3 interpretaciones por día",
+      "feature2": "Modelo de IA básico",
+      "feature3": "Sin necesidad de cuenta",
+      "cta": "Plan actual"
+    },
+    "premium": {
+      "badge": "Popular",
+      "price": "$4.99",
+      "description": "Para quienes quieren profundizar en sus sueños",
+      "feature1": "Interpretaciones ilimitadas",
+      "feature2": "Modelo de IA avanzado (Claude)",
+      "feature3": "Diario de sueños privado",
+      "feature4": "Historial completo",
+      "cta": "Comenzar con Premium",
+      "manage": "Gestionar suscripción"
+    }
+  },
   "Auth": {
     "signIn": "Iniciar sesión",
     "signUp": "Crear cuenta",

--- a/messages/es.json
+++ b/messages/es.json
@@ -17,6 +17,17 @@
     "interpreting": "Interpretando...",
     "clearDream": "Borrar sueño"
   },
+  "Billing": {
+    "title": "Tu suscripción",
+    "subtitle": "Gestiona tu plan y métodos de pago",
+    "currentPlan": "Plan actual",
+    "freePlan": "Gratis",
+    "upgradeToPremium": "Actualizar a Premium",
+    "manageSubscription": "Gestionar suscripción",
+    "loading": "Cargando...",
+    "successMessage": "¡Pago exitoso! Ya tienes acceso a Premium.",
+    "canceledMessage": "El pago fue cancelado. Puedes intentarlo de nuevo cuando quieras."
+  },
   "Pricing": {
     "title": "Planes simples y transparentes",
     "subtitle": "Empieza gratis y actualiza cuando quieras acceder a más.",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-slot": "1.2.2",
     "@radix-ui/react-tabs": "1.1.11",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@stripe/stripe-js": "^8.9.0",
     "@vercel/analytics": "^1.5.0",
     "ai": "4.3.16",
     "bcryptjs": "^3.0.3",
@@ -28,6 +29,7 @@
     "prisma": "^5",
     "react": "19.0.0",
     "react-dom": "19.0.0",
+    "stripe": "^20.4.1",
     "tailwind-merge": "3.3.0",
     "vercel": "^50.32.5",
     "zod": "^4.3.6"


### PR DESCRIPTION
## Resumen
- `lib/stripe.ts` — singleton de Stripe (pauta del proyecto)
- `POST /api/stripe/checkout` — crea Checkout Session, reutiliza o crea `stripeCustomerId`
- `POST /api/stripe/portal` — crea Customer Portal Session para gestionar suscripción
- `POST /api/stripe/webhook` — sincroniza `isPremium` en la BD ante eventos de Stripe
- `app/[locale]/pricing` — página de pricing con tarjetas Free/Premium
- Traducciones EN/ES para el namespace `Pricing`

## Eventos manejados en el webhook
- `checkout.session.completed` → activa `isPremium = true`
- `customer.subscription.updated` → sincroniza según `status` (active/trialing/past_due…)
- `customer.subscription.deleted` → desactiva `isPremium = false`
- `invoice.payment_failed` → revoca acceso si la sub está en `past_due` o `unpaid`

## Variables de entorno necesarias
```
STRIPE_SECRET_KEY=
NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
STRIPE_WEBHOOK_SECRET=
NEXT_PUBLIC_STRIPE_PRICE_ID=
```

## Test plan
- [ ] Crear producto en Stripe Dashboard y copiar Price ID a `.env.local`
- [ ] Probar flujo de upgrade en `/pricing` (modo test con tarjeta `4242 4242 4242 4242`)
- [ ] Verificar que `isPremium` se activa en BD tras `checkout.session.completed`
- [ ] Probar webhook local con `stripe listen --forward-to localhost:3000/api/stripe/webhook`
- [ ] Verificar que Customer Portal permite cancelar y que `isPremium` se desactiva

Cierra LES-22 y LES-23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)