### PR TITLE
Add input validation and character limit for dream interpretation

### DIFF
--- a/app/api/interpret/route.ts
+++ b/app/api/interpret/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from "next/server";
 import { headers } from "next/headers";
+import { z } from "zod";
 import { auth } from "@/lib/auth";
 import { checkAnonLimit, checkFreeLimit } from "@/lib/ratelimit";
+
+const interpretSchema = z.object({
+  dream: z.string().min(1).max(2000),
+  locale: z.enum(["es", "en"]).default("es"),
+});
 
 const FREE_MODELS = [
   "nvidia/nemotron-3-nano-30b-a3b:free",
@@ -119,14 +125,11 @@ Provide a general and deep interpretation of the dream. In a single paragraph, i
 export async function POST(req: Request) {
   try {
     const [session, headersList] = await Promise.all([auth(), headers()]);
-    const { dream, locale } = await req.json();
-
-    if (!dream) {
-      return NextResponse.json(
-        { error: "A dream is required for interpretation" },
-        { status: 400 }
-      );
+    const parseResult = interpretSchema.safeParse(await req.json());
+    if (!parseResult.success) {
+      return NextResponse.json({ error: "Invalid input" }, { status: 400 });
     }
+    const { dream, locale } = parseResult.data;
 
     const isPremium = session?.user?.isPremium ?? false;
     const userId = session?.user?.id;

--- a/components/text-box.tsx
+++ b/components/text-box.tsx
@@ -196,6 +196,7 @@ export default function TextBox({
                   aria-label={t("placeholder")}
                   className="w-full min-h-[10rem] sm:min-h-[8rem] max-h-[14rem] resize-none border-0 bg-transparent focus-visible:ring-0 shadow-none px-5 pt-5 pb-2 text-base leading-relaxed placeholder:text-muted-foreground/40"
                   value={dream}
+                  maxLength={2000}
                   onChange={(e) => setDream(e.target.value)}
                   onFocus={() => setIsFocused(true)}
                   onBlur={() => setIsFocused(false)}
@@ -275,11 +276,13 @@ export default function TextBox({
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: 4 }}
                     transition={{ duration: 0.2 }}
-                    className="text-xs text-muted-foreground/60 tabular-nums select-none"
+                    className={`text-xs tabular-nums select-none ${
+                      dream.length > 1500 ? "text-destructive/80" : "text-muted-foreground/60"
+                    }`}
                     aria-live="polite"
-                    aria-label={`${dream.length} characters`}
+                    aria-label={`${dream.length} of 2000 characters`}
                   >
-                    {dream.length}
+                    {dream.length > 1500 ? `${dream.length}/2000` : dream.length}
                   </motion.span>
                 )
               )}


### PR DESCRIPTION
## Summary
This PR adds robust input validation to the dream interpretation API and implements a character limit with visual feedback in the UI.

## Key Changes
- **API Validation**: Implemented Zod schema validation for the `/api/interpret` endpoint to validate dream text (1-2000 characters) and locale (es/en)
- **Character Limit**: Added 2000 character maximum length constraint to the dream textarea input
- **Visual Feedback**: Enhanced character counter to:
  - Display current count when under 1500 characters
  - Show "current/2000" format when approaching the limit (>1500 characters)
  - Change counter color to destructive/warning state when nearing the limit
- **Improved Error Handling**: Replaced manual validation with schema-based validation for cleaner, more maintainable code

## Implementation Details
- Uses Zod's `safeParse()` for non-throwing validation with detailed error information
- Character counter dynamically updates styling based on proximity to the 2000 character limit
- Textarea `maxLength` attribute prevents users from exceeding the limit
- Accessibility improvements with updated `aria-label` to show the limit context

https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR