### PR TITLE
fix: use request locale in password reset email link (LES-97)

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -4,7 +4,10 @@ import crypto from "crypto";
 import { prisma } from "@/lib/prisma";
 import { getResend } from "@/lib/email";
 
-const schema = z.object({ email: z.string().email() });
+const schema = z.object({
+  email: z.string().email(),
+  locale: z.enum(["es", "en"]).default("es"),
+});
 
 export async function POST(req: Request) {
   const body = await req.json();
@@ -13,7 +16,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid email" }, { status: 400 });
   }
 
-  const { email } = parsed.data;
+  const { email, locale } = parsed.data;
 
   // Always return success to avoid user enumeration
   const user = await prisma.user.findUnique({ where: { email }, select: { id: true, name: true, password: true } });
@@ -28,7 +31,7 @@ export async function POST(req: Request) {
     await prisma.verificationToken.create({ data: { identifier: email, token, expires } });
 
     const origin = req.headers.get("origin") ?? process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
-    const resetUrl = `${origin}/es/reset-password?token=${token}&email=${encodeURIComponent(email)}`;
+    const resetUrl = `${origin}/${locale}/reset-password?token=${token}&email=${encodeURIComponent(email)}`;
 
     const from =
       process.env.NODE_ENV === "production"

--- a/components/auth/forgot-password-form.tsx
+++ b/components/auth/forgot-password-form.tsx
@@ -29,7 +29,7 @@ export function ForgotPasswordForm({ locale }: { locale: string }) {
       await fetch("/api/auth/forgot-password", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, locale }),
       });
       setSent(true);
     } catch {


### PR DESCRIPTION
## Summary

- Pass `locale` from `ForgotPasswordForm` to `POST /api/auth/forgot-password` in the request body
- Add `locale` field to the Zod schema in the route (enum `"es" | "en"`, default `"es"`)
- Replace hardcoded `/es/reset-password` with `/${locale}/reset-password` in the reset URL

## Test plan

- [ ] Request a password reset while browsing in `/en` — verify the email link points to `/en/reset-password`
- [ ] Request a password reset while browsing in `/es` — verify the email link points to `/es/reset-password`
- [ ] Verify existing behavior unchanged: token is valid and password reset completes successfully in both locales

Closes LES-97

https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR)_