### PR TITLE
feat(security): add HTTP security headers (LES-98)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,20 @@ const nextConfig: NextConfig = {
       { protocol: "https", hostname: "lh3.googleusercontent.com" },
     ],
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+          { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains; preload" },
+        ],
+      },
+    ];
+  },
   turbopack: {
     resolveAlias: {
       "next-intl/config": "./i18n/request.ts",


### PR DESCRIPTION
## Summary

- Add `headers()` to `next.config.ts` applying security headers to all routes (`/(.*)`):
  - `X-Frame-Options: DENY` — prevents clickjacking
  - `X-Content-Type-Options: nosniff` — prevents MIME sniffing
  - `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage
  - `Permissions-Policy: camera=(), microphone=(), geolocation=()` — disables unused browser APIs
  - `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload` — enforces HTTPS

A full CSP is deferred due to Tailwind inline styles and third-party scripts (Vercel Analytics, Stripe).

## Test plan

- [ ] Deploy to preview and verify headers are present with `curl -I <url>` or browser DevTools → Network → response headers
- [ ] Confirm no regressions in Stripe Checkout, Google OAuth, and Vercel Analytics
- [ ] Run [securityheaders.com](https://securityheaders.com) against the preview URL — score should improve significantly

Closes LES-98

https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR)_