### PR TITLE
feat(security): rate limit register and forgot-password endpoints (LES-96)

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -3,10 +3,17 @@ import { z } from "zod";
 import crypto from "crypto";
 import { prisma } from "@/lib/prisma";
 import { getResend } from "@/lib/email";
+import { checkForgotPasswordLimit } from "@/lib/ratelimit";
 
 const schema = z.object({ email: z.string().email() });
 
 export async function POST(req: Request) {
+  const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  const limit = await checkForgotPasswordLimit(ip);
+  if (!limit.success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
   const body = await req.json();
   const parsed = schema.safeParse(body);
   if (!parsed.success) {

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import bcrypt from "bcryptjs";
 import { prisma } from "@/lib/prisma";
+import { checkRegisterLimit } from "@/lib/ratelimit";
 
 const registerSchema = z.object({
   name: z.string().min(1),
@@ -11,6 +12,12 @@ const registerSchema = z.object({
 
 export async function POST(req: Request) {
   try {
+    const ip = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+    const limit = await checkRegisterLimit(ip);
+    if (!limit.success) {
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
+
     const body = await req.json();
     const parsed = registerSchema.safeParse(body);
 

--- a/lib/ratelimit.ts
+++ b/lib/ratelimit.ts
@@ -10,14 +10,15 @@ const redis =
 
 async function checkLimit(
   key: string,
-  limit: number
+  limit: number,
+  ttl = 86400
 ): Promise<{ success: boolean; remaining: number; limit: number }> {
   if (!redis) return { success: true, remaining: limit, limit };
 
   try {
     const count = await redis.incr(key);
     if (count === 1) {
-      await redis.expire(key, 86400); // reset after 24h
+      await redis.expire(key, ttl);
     }
     const remaining = Math.max(0, limit - count);
     return { success: count <= limit, remaining, limit };
@@ -37,4 +38,18 @@ export async function checkFreeLimit(
   userId: string
 ): Promise<{ success: boolean; remaining: number; limit: number }> {
   return checkLimit(`dream:free:${userId}`, 5);
+}
+
+// 5 registration attempts per IP per 15 minutes
+export async function checkRegisterLimit(
+  ip: string
+): Promise<{ success: boolean }> {
+  return checkLimit(`auth:register:${ip}`, 5, 900);
+}
+
+// 3 forgot-password requests per IP per hour
+export async function checkForgotPasswordLimit(
+  ip: string
+): Promise<{ success: boolean }> {
+  return checkLimit(`auth:forgot-password:${ip}`, 3, 3600);
 }


### PR DESCRIPTION
## Summary

- Add `checkRegisterLimit` to `lib/ratelimit.ts`: 5 attempts per IP per 15 minutes
- Add `checkForgotPasswordLimit` to `lib/ratelimit.ts`: 3 requests per IP per hour
- Apply both checks at the start of their respective handlers, before any DB query or email send, returning `429 Too Many Requests` on excess
- Add `ttl` parameter to the internal `checkLimit` helper to support arbitrary window sizes (existing behavior unchanged — defaults to 86400)

Both functions reuse the existing Upstash Redis infrastructure. If Redis is unavailable, requests pass through (fail open), consistent with current behavior.

## Test plan

- [ ] Send 6+ rapid registration requests from the same IP — 6th should return 429
- [ ] Send 4+ forgot-password requests from the same IP within an hour — 4th should return 429
- [ ] Verify normal registration and password reset still work within the limits
- [ ] Verify Redis unavailability (empty env vars) does not break either endpoint

Closes LES-96

https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR)_