### PR TITLE
fix(journal): store dreamDate as YYYY-MM-DD string to fix timezone bug — LES-103

### DIFF
--- a/app/[locale]/journal/[id]/page.tsx
+++ b/app/[locale]/journal/[id]/page.tsx
@@ -23,6 +23,7 @@ export default async function JournalEntryPage({
       interpretation: true,
       mood: true,
       tags: true,
+      dreamDate: true,
       createdAt: true,
       userId: true,
     },
@@ -37,6 +38,7 @@ export default async function JournalEntryPage({
     interpretation: entry.interpretation,
     mood: entry.mood,
     tags: entry.tags,
+    dreamDate: entry.dreamDate ?? null,
     createdAt: entry.createdAt.toISOString(),
   };
 

--- a/app/[locale]/journal/page.tsx
+++ b/app/[locale]/journal/page.tsx
@@ -35,6 +35,7 @@ export default async function JournalPage({
         interpretation: true,
         mood: true,
         tags: true,
+        dreamDate: true,
         createdAt: true,
       },
     }),
@@ -43,6 +44,7 @@ export default async function JournalPage({
 
   const serialized = entries.map((e) => ({
     ...e,
+    dreamDate: e.dreamDate ?? null,
     createdAt: e.createdAt.toISOString(),
   }));
 

--- a/app/api/journal/[id]/route.ts
+++ b/app/api/journal/[id]/route.ts
@@ -39,7 +39,7 @@ export async function PATCH(
   });
 
   return NextResponse.json({
-    entry: { ...updated, createdAt: updated.createdAt.toISOString() },
+    entry: { ...updated, createdAt: updated.createdAt.toISOString(), dreamDate: updated.dreamDate ?? null },
   });
 }
 

--- a/app/api/journal/route.ts
+++ b/app/api/journal/route.ts
@@ -31,6 +31,7 @@ export async function GET(req: Request) {
         interpretation: true,
         mood: true,
         tags: true,
+        dreamDate: true,
         createdAt: true,
       },
     }),
@@ -38,7 +39,7 @@ export async function GET(req: Request) {
   ]);
 
   return NextResponse.json({
-    entries: entries.map((e) => ({ ...e, createdAt: e.createdAt.toISOString() })),
+    entries: entries.map((e) => ({ ...e, createdAt: e.createdAt.toISOString(), dreamDate: e.dreamDate ?? null })),
     total,
     hasMore: skip + entries.length < total,
     page,
@@ -66,21 +67,17 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid data" }, { status: 400 });
   }
 
-  const createdAt = parsed.data.dreamDate
-    ? new Date(`${parsed.data.dreamDate}T12:00:00`)
-    : undefined;
-
   const entry = await prisma.dreamEntry.create({
     data: {
       userId: session.user.id,
       dreamText: parsed.data.dreamText,
       interpretation: parsed.data.interpretation,
-      ...(createdAt && { createdAt }),
+      ...(parsed.data.dreamDate && { dreamDate: parsed.data.dreamDate }),
     },
   });
 
   return NextResponse.json(
-    { entry: { ...entry, createdAt: entry.createdAt.toISOString() } },
+    { entry: { ...entry, createdAt: entry.createdAt.toISOString(), dreamDate: entry.dreamDate ?? null } },
     { status: 201 }
   );
 }

--- a/components/journal/dream-detail.tsx
+++ b/components/journal/dream-detail.tsx
@@ -8,8 +8,9 @@ import { Loader2, ArrowLeft, Pencil, Trash2 } from "lucide-react";
 import { MOODS, getMoodEmoji } from "@/lib/moods";
 import type { JournalEntry } from "@/types/journal";
 
-function formatDate(iso: string, locale: string) {
-  return new Date(iso).toLocaleDateString(locale === "es" ? "es-ES" : "en-US", {
+function formatDate(dreamDate: string | null, createdAt: string, locale: string) {
+  const d = dreamDate ? new Date(`${dreamDate}T00:00:00`) : new Date(createdAt);
+  return d.toLocaleDateString(locale === "es" ? "es-ES" : "en-US", {
     weekday: "long",
     day: "numeric",
     month: "long",
@@ -129,7 +130,7 @@ export function DreamDetail({ entry }: { entry: JournalEntry }) {
             )}
             <div className="flex items-center gap-2">
               <p className="text-xs text-muted-foreground">
-                {formatDate(entry.createdAt, locale)}
+                {formatDate(entry.dreamDate, entry.createdAt, locale)}
               </p>
               {displayEmoji && (
                 <span className="text-sm">{displayEmoji}</span>

--- a/components/journal/journal-list.tsx
+++ b/components/journal/journal-list.tsx
@@ -20,7 +20,9 @@ function groupEntriesByDate(
   const groups: Map<string, JournalEntry[]> = new Map();
 
   for (const entry of entries) {
-    const d = new Date(entry.createdAt);
+    const d = entry.dreamDate
+      ? new Date(`${entry.dreamDate}T00:00:00`)
+      : new Date(entry.createdAt);
     const entryDay = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
 
     let label: string;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,7 @@ model DreamEntry {
   interpretation String?
   mood           String?
   tags           String[]
+  dreamDate      String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/types/journal.ts
+++ b/types/journal.ts
@@ -5,5 +5,6 @@ export type JournalEntry = {
   interpretation: string | null;
   mood: string | null;
   tags: string[];
+  dreamDate: string | null;
   createdAt: string;
 };


### PR DESCRIPTION
## What changes?

- Adds `dreamDate String?` field to `DreamEntry` in Prisma schema to store the user-selected date as a plain `YYYY-MM-DD` string, bypassing UTC conversion entirely
- Removes the previous hack that overrode `createdAt` with `T12:00:00` (which shifted the date for users in UTC+13/UTC+14 or other extreme offsets)
- Updates grouping and display logic across the journal to use `dreamDate` when present, falling back to `createdAt` for entries without a user-selected date

## Modified files

- `prisma/schema.prisma` — adds `dreamDate String?` to `DreamEntry`
- `app/api/journal/route.ts` — stores `dreamDate` directly; removes `createdAt` override; returns field in GET and POST responses
- `app/api/journal/[id]/route.ts` — includes `dreamDate` in PATCH response
- `app/[locale]/journal/page.tsx` — selects and serializes `dreamDate`
- `app/[locale]/journal/[id]/page.tsx` — selects and serializes `dreamDate`
- `components/journal/journal-list.tsx` — groups entries by `dreamDate` when available
- `components/journal/dream-detail.tsx` — displays `dreamDate` when available
- `types/journal.ts` — adds `dreamDate: string | null` to `JournalEntry`

## Acceptance criteria

- [ ] Saving a dream with a past date stores the exact `YYYY-MM-DD` string without any timezone shift
- [ ] The journal list groups the entry under the correct user-selected day regardless of the user's timezone
- [ ] The dream detail view shows the correct date for entries with a user-selected date
- [ ] Entries without a user-selected date (today's dreams) continue to display correctly using `createdAt`
- [ ] Existing entries without `dreamDate` are unaffected (field is nullable, falls back to `createdAt`)

## Linear

Closes LES-103