### PR TITLE
feat: landing page how-it-works and premium features section (LES-117)

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
 import { getTranslations } from "next-intl/server";
-import { Sparkles, BookOpen } from "lucide-react";
+import { Sparkles, BookOpen, ChevronDown } from "lucide-react";
 import { DreamSection } from "@/components/dream-section";
 import { HomeAnimations } from "@/components/home-animations";
 import { HomeFeatures } from "@/components/home-features";
@@ -15,14 +15,16 @@ export default async function Home({
   const [t, session] = await Promise.all([getTranslations("Home"), auth()]);
 
   return (
-    <div className="relative flex flex-1 flex-col items-center justify-between w-full">
-      <div className="relative z-10 flex-1 flex items-center w-full">
-        <div className="flex flex-col items-center gap-3 w-full px-4">
+    <div className="relative flex flex-1 flex-col items-center w-full">
+
+      {/* Hero — fills the full viewport below the header */}
+      <div className="relative z-10 flex flex-col items-center justify-center w-full min-h-[calc(100vh-3rem)] px-4 py-16">
+        <div className="flex flex-col items-center gap-10 w-full">
 
           <HomeAnimations>
             {/* icon */}
             <div>
-              <div className="relative flex items-center justify-center w-14 h-14 rounded-2xl mb-1">
+              <div className="relative flex items-center justify-center w-14 h-14 rounded-2xl">
                 <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-primary/20 to-secondary/20 blur-sm" />
                 <div className="relative flex items-center justify-center w-14 h-14 rounded-2xl bg-primary/10 border border-primary/20 shadow-[0_0_24px_oklch(var(--tw-shadow-color)/0.15)] shadow-primary">
                   <Sparkles className="w-6 h-6 text-primary" />
@@ -31,9 +33,7 @@ export default async function Home({
             </div>
 
             {/* title */}
-            <h1
-              className="text-5xl md:text-6xl font-bold tracking-tight text-center bg-gradient-to-br from-primary via-primary/85 to-secondary bg-clip-text text-transparent leading-tight pb-1"
-            >
+            <h1 className="text-5xl md:text-6xl font-bold tracking-tight text-center bg-gradient-to-br from-primary via-primary/85 to-secondary bg-clip-text text-transparent leading-tight pb-1">
               {t("title")}
             </h1>
           </HomeAnimations>
@@ -44,18 +44,18 @@ export default async function Home({
           {/* auth CTA — solo cuando no hay sesión */}
           {!session?.user ? (
             <div
-              className="flex items-center gap-2 opacity-0"
+              className="flex items-center gap-3 opacity-0"
               style={{ animation: "fade-up 0.6s ease-out 0.6s both" }}
             >
               <Link
                 href={`/${locale}/sign-up`}
-                className="flex items-center rounded-full bg-gradient-to-r from-primary to-secondary px-4 py-2 text-xs font-medium text-primary-foreground shadow-md shadow-primary/20 transition-opacity hover:opacity-90"
+                className="flex items-center rounded-full bg-gradient-to-r from-primary to-secondary px-5 py-2.5 text-sm font-medium text-primary-foreground shadow-md shadow-primary/20 transition-opacity hover:opacity-90"
               >
                 {t("createAccount")}
               </Link>
               <Link
                 href={`/${locale}/sign-in`}
-                className="flex items-center rounded-full border border-border px-3.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:border-primary/60 transition-colors duration-200"
+                className="flex items-center rounded-full border border-border px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:border-primary/60 transition-colors duration-200"
               >
                 {t("signIn")}
               </Link>
@@ -67,7 +67,7 @@ export default async function Home({
             >
               <Link
                 href={`/${locale}/journal`}
-                className="flex items-center gap-1.5 rounded-full border border-border px-3.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:border-primary/60 transition-colors duration-200"
+                className="flex items-center gap-1.5 rounded-full border border-border px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:border-primary/60 transition-colors duration-200"
               >
                 <BookOpen className="w-3.5 h-3.5" />
                 {t("viewJournal")}
@@ -76,6 +76,16 @@ export default async function Home({
           )}
 
         </div>
+
+        {/* Scroll indicator — visible only when there's content below */}
+        {!session?.user && (
+          <div
+            className="absolute bottom-8 opacity-0"
+            style={{ animation: "fade-up 0.6s ease-out 1.4s both" }}
+          >
+            <ChevronDown className="w-5 h-5 text-muted-foreground/30 animate-bounce" />
+          </div>
+        )}
       </div>
 
       {/* Features section — solo para usuarios anónimos */}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -2,6 +2,7 @@ import { getTranslations } from "next-intl/server";
 import { Sparkles, BookOpen } from "lucide-react";
 import { DreamSection } from "@/components/dream-section";
 import { HomeAnimations } from "@/components/home-animations";
+import { HomeFeatures } from "@/components/home-features";
 import { auth } from "@/lib/auth";
 import Link from "next/link";
 
@@ -76,6 +77,10 @@ export default async function Home({
 
         </div>
       </div>
+
+      {/* Features section — solo para usuarios anónimos */}
+      {!session?.user && <HomeFeatures locale={locale} />}
+
     </div>
   );
 }

--- a/components/dream-section.tsx
+++ b/components/dream-section.tsx
@@ -50,56 +50,58 @@ export function DreamSection({ subtitle }: { subtitle: string }) {
   return (
     <>
       <OnboardingModal />
-      {/* subtitle / interpretation */}
-      <div
-        className="w-full flex justify-center mt-2 opacity-0"
-        style={{ animation: "fade-up 0.6s ease-out 0.3s both" }}
-      >
-        <AnimatePresence mode="wait">
-          {interpretation ? (
-            <motion.div
-              key="interpretation"
-              initial={{ opacity: 0, y: 12, filter: "blur(6px)" }}
-              animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
-              exit={{ opacity: 0, y: -12, filter: "blur(6px)" }}
-              transition={{ duration: 0.5, ease: "easeOut" }}
-              className="relative max-w-2xl w-full mx-auto rounded-2xl border border-primary/20 bg-primary/5 backdrop-blur-sm px-6 py-5"
-            >
-              <div className="absolute top-0 left-0 w-16 h-16 rounded-tl-2xl bg-gradient-to-br from-primary/10 to-transparent pointer-events-none" />
-              {isPremiumModel && (
-                <span className="absolute top-3 right-3 flex items-center gap-1 text-[10px] font-medium text-primary/60 select-none">
-                  ✨ Claude
-                </span>
-              )}
-              <p className="relative text-base md:text-lg text-foreground/80 leading-relaxed text-center">
-                <WordReveal text={interpretation} />
-              </p>
-            </motion.div>
-          ) : (
-            <motion.p
-              key="subtitle"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              transition={{ duration: 0.3 }}
-              className="text-lg md:text-xl text-center text-muted-foreground/70 max-w-md"
-            >
-              {subtitle}
-            </motion.p>
-          )}
-        </AnimatePresence>
-      </div>
+      <div className="flex flex-col items-center gap-5 w-full">
+        {/* subtitle / interpretation */}
+        <div
+          className="w-full flex justify-center opacity-0"
+          style={{ animation: "fade-up 0.6s ease-out 0.3s both" }}
+        >
+          <AnimatePresence mode="wait">
+            {interpretation ? (
+              <motion.div
+                key="interpretation"
+                initial={{ opacity: 0, y: 12, filter: "blur(6px)" }}
+                animate={{ opacity: 1, y: 0, filter: "blur(0px)" }}
+                exit={{ opacity: 0, y: -12, filter: "blur(6px)" }}
+                transition={{ duration: 0.5, ease: "easeOut" }}
+                className="relative max-w-2xl w-full mx-auto rounded-2xl border border-primary/20 bg-primary/5 backdrop-blur-sm px-6 py-5"
+              >
+                <div className="absolute top-0 left-0 w-16 h-16 rounded-tl-2xl bg-gradient-to-br from-primary/10 to-transparent pointer-events-none" />
+                {isPremiumModel && (
+                  <span className="absolute top-3 right-3 flex items-center gap-1 text-[10px] font-medium text-primary/60 select-none">
+                    ✨ Claude
+                  </span>
+                )}
+                <p className="relative text-base md:text-lg text-foreground/80 leading-relaxed text-center">
+                  <WordReveal text={interpretation} />
+                </p>
+              </motion.div>
+            ) : (
+              <motion.p
+                key="subtitle"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.3 }}
+                className="text-lg md:text-xl text-center text-muted-foreground/70 max-w-md"
+              >
+                {subtitle}
+              </motion.p>
+            )}
+          </AnimatePresence>
+        </div>
 
-      {/* textbox */}
-      <div
-        className="w-full flex justify-center opacity-0"
-        style={{ animation: "fade-up 0.6s ease-out 0.45s both" }}
-      >
-        <TextBox
-          interpretation={interpretation}
-          setInterpretation={setInterpretation}
-          setIsPremiumModel={setIsPremiumModel}
-        />
+        {/* textbox */}
+        <div
+          className="w-full flex justify-center opacity-0"
+          style={{ animation: "fade-up 0.6s ease-out 0.45s both" }}
+        >
+          <TextBox
+            interpretation={interpretation}
+            setInterpretation={setInterpretation}
+            setIsPremiumModel={setIsPremiumModel}
+          />
+        </div>
       </div>
     </>
   );

--- a/components/home-animations.tsx
+++ b/components/home-animations.tsx
@@ -11,7 +11,7 @@ const item = {
 export function HomeAnimations({ children }: { children: React.ReactNode }) {
   return (
     <motion.div
-      className="flex flex-col items-center gap-3"
+      className="flex flex-col items-center gap-5"
       initial="hidden"
       animate="show"
       transition={{ staggerChildren: 0.1, delayChildren: 0.1 }}

--- a/components/home-features.tsx
+++ b/components/home-features.tsx
@@ -1,0 +1,84 @@
+import { getTranslations } from "next-intl/server";
+import { Pencil, Cpu, Lightbulb, Infinity, Sparkles, BookOpen } from "lucide-react";
+import Link from "next/link";
+
+export async function HomeFeatures({ locale }: { locale: string }) {
+  const t = await getTranslations("HomeFeatures");
+
+  const steps = [
+    { icon: Pencil, title: t("step1Title"), desc: t("step1Desc") },
+    { icon: Cpu,    title: t("step2Title"), desc: t("step2Desc") },
+    { icon: Lightbulb, title: t("step3Title"), desc: t("step3Desc") },
+  ];
+
+  const premiumCards = [
+    { icon: Infinity,  title: t("premium1Title"), desc: t("premium1Desc") },
+    { icon: Sparkles,  title: t("premium2Title"), desc: t("premium2Desc") },
+    { icon: BookOpen,  title: t("premium3Title"), desc: t("premium3Desc") },
+  ];
+
+  return (
+    <section className="w-full max-w-3xl mx-auto px-4 pb-20 flex flex-col gap-20">
+
+      {/* How it works */}
+      <div
+        className="opacity-0"
+        style={{ animation: "fade-up 0.6s ease-out 0.9s both" }}
+      >
+        <h2 className="text-center text-sm font-semibold uppercase tracking-widest text-muted-foreground/50 mb-8">
+          {t("howItWorksHeading")}
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+          {steps.map(({ icon: Icon, title, desc }, i) => (
+            <div key={i} className="flex flex-col items-center text-center gap-3">
+              <div className="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10 border border-primary/20">
+                <Icon className="w-5 h-5 text-primary" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-foreground mb-1">{title}</p>
+                <p className="text-xs text-muted-foreground leading-relaxed">{desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Premium features */}
+      <div
+        className="opacity-0"
+        style={{ animation: "fade-up 0.6s ease-out 1.1s both" }}
+      >
+        <h2 className="text-center text-sm font-semibold uppercase tracking-widest text-muted-foreground/50 mb-8">
+          {t("premiumHeading")}
+        </h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-8">
+          {premiumCards.map(({ icon: Icon, title, desc }, i) => (
+            <div
+              key={i}
+              className="flex flex-col gap-3 rounded-2xl border border-border bg-card/50 p-5"
+            >
+              <div className="flex items-center justify-center w-9 h-9 rounded-xl bg-primary/10 border border-primary/20 self-start">
+                <Icon className="w-4 h-4 text-primary" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-foreground mb-1">{title}</p>
+                <p className="text-xs text-muted-foreground leading-relaxed">{desc}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Closing CTA */}
+        <div className="flex justify-center">
+          <Link
+            href={`/${locale}/sign-up`}
+            className="flex items-center rounded-full bg-gradient-to-r from-primary to-secondary px-6 py-2.5 text-sm font-medium text-primary-foreground shadow-md shadow-primary/20 transition-opacity hover:opacity-90"
+          >
+            {t("cta")}
+          </Link>
+        </div>
+      </div>
+
+    </section>
+  );
+}

--- a/components/home-features.tsx
+++ b/components/home-features.tsx
@@ -18,7 +18,7 @@ export async function HomeFeatures({ locale }: { locale: string }) {
   ];
 
   return (
-    <section className="w-full max-w-3xl mx-auto px-4 pb-20 flex flex-col gap-20">
+    <section className="w-full max-w-3xl mx-auto px-4 pt-20 pb-24 flex flex-col gap-24">
 
       {/* How it works */}
       <div

--- a/messages/en.json
+++ b/messages/en.json
@@ -6,6 +6,23 @@
     "madeWith": "Made with",
     "by": "by"
   },
+  "HomeFeatures": {
+    "howItWorksHeading": "How it works",
+    "step1Title": "Describe your dream",
+    "step1Desc": "Write what you remember: people, places, feelings.",
+    "step2Title": "AI analyzes it",
+    "step2Desc": "A psychoanalytic model identifies symbols and unconscious patterns.",
+    "step3Title": "Discover its meaning",
+    "step3Desc": "Receive a deep interpretation tailored to your dream.",
+    "premiumHeading": "With Premium, so much more",
+    "premium1Title": "Unlimited interpretations",
+    "premium1Desc": "No daily limit. Interpret as many dreams as you want.",
+    "premium2Title": "Advanced AI with Claude",
+    "premium2Desc": "Access a superior model for deeper and more accurate interpretations.",
+    "premium3Title": "Private dream journal",
+    "premium3Desc": "Save, organize, and revisit all your interpretations in one place.",
+    "cta": "Create free account"
+  },
   "Home": {
     "title": "Interpret your dreams",
     "subtitle": "Describe your dream and discover its meaning",

--- a/messages/es.json
+++ b/messages/es.json
@@ -6,6 +6,23 @@
     "madeWith": "Hecho con",
     "by": "por"
   },
+  "HomeFeatures": {
+    "howItWorksHeading": "Cómo funciona",
+    "step1Title": "Describe tu sueño",
+    "step1Desc": "Escribe lo que recuerdas: personajes, lugares, emociones.",
+    "step2Title": "La IA lo analiza",
+    "step2Desc": "Un modelo psicoanalítico identifica símbolos y patrones inconscientes.",
+    "step3Title": "Descubre su significado",
+    "step3Desc": "Recibe una interpretación profunda adaptada a tu sueño.",
+    "premiumHeading": "Con Premium, mucho más",
+    "premium1Title": "Interpretaciones ilimitadas",
+    "premium1Desc": "Sin límite diario. Interpreta todos los sueños que quieras.",
+    "premium2Title": "IA avanzada con Claude",
+    "premium2Desc": "Accede a un modelo superior para interpretaciones más profundas y precisas.",
+    "premium3Title": "Diario de sueños privado",
+    "premium3Desc": "Guarda, organiza y revisa todas tus interpretaciones en un solo lugar.",
+    "cta": "Crear cuenta gratis"
+  },
   "Home": {
     "title": "Interpreta tus sueños",
     "subtitle": "Describe tu sueño y descubre su significado",


### PR DESCRIPTION
## Summary

- Add `components/home-features.tsx` — pure Server Component with two sections:
  - **How it works**: 3 steps (describe → AI analyzes → discover meaning) with icons and `fade-up` staggered animations
  - **Premium features**: 3 cards (unlimited, advanced AI, journal) + closing "Create free account" CTA button
- Section is rendered in `app/[locale]/page.tsx` only when `!session?.user`
- All text in i18n under `HomeFeatures` namespace (ES + EN)
- No `"use client"`, no Framer Motion — uses existing CSS `fade-up` keyframe with `animation-delay`

## Test plan

- [ ] Visit `/es` as anonymous user — verify both sections appear below the widget
- [ ] Visit `/en` as anonymous user — verify text is in English
- [ ] Sign in and visit `/` — verify sections are NOT shown
- [ ] Check animations match the rest of the page

Closes LES-117

https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR)_