### PR TITLE
feat(seo): add sitemap.xml and robots.txt (LES-115)

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/es/", "/en/"],
+        disallow: [
+          "/es/journal",
+          "/en/journal",
+          "/es/profile",
+          "/en/profile",
+          "/es/billing",
+          "/en/billing",
+          "/api/",
+        ],
+      },
+    ],
+    sitemap: `${process.env.NEXT_PUBLIC_APP_URL}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = process.env.NEXT_PUBLIC_APP_URL!;
+  const locales = ["es", "en"];
+  const publicRoutes = ["", "/pricing", "/sign-in", "/sign-up", "/support", "/privacy", "/terms"];
+
+  return locales.flatMap((locale) =>
+    publicRoutes.map((route) => ({
+      url: `${base}/${locale}${route}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: route === "" ? 1.0 : 0.8,
+    }))
+  );
+}


### PR DESCRIPTION
## Summary

- **`app/sitemap.ts`** — generates `sitemap.xml` with all public routes for `es` and `en` locales (`/`, `/pricing`, `/sign-in`, `/sign-up`, `/support`, `/privacy`, `/terms`). Home page gets priority `1.0`, rest `0.8`, all with `weekly` changeFrequency.
- **`app/robots.ts`** — generates `robots.txt` allowing `/es/` and `/en/`, disallowing private routes (`/journal`, `/profile`, `/billing`) and `/api/` for all crawlers. Includes sitemap reference.

Both are rendered as static routes by Next.js App Router (`○ /sitemap.xml`, `○ /robots.txt` confirmed in build output).

## Test plan

- [ ] `<APP_URL>/sitemap.xml` — verify valid XML with 14 public URLs (7 routes × 2 locales)
- [ ] `<APP_URL>/robots.txt` — verify disallow rules and sitemap reference are correct
- [ ] Submit sitemap to Google Search Console and confirm no errors

Closes LES-115

https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR

---
_Generated by [Claude Code](https://claude.ai/code/session_01HmrZyJr13Zmx4BqYogPRmR)_